### PR TITLE
Update wallaby.js

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -1,5 +1,4 @@
-module.exports = function (w) {
-
+module.exports = function (wallaby) {
   return {
     files: [
       'src/**/*.js',
@@ -8,14 +7,34 @@ module.exports = function (w) {
     tests: [
       'src/**/*.test.js'
     ],
-    testFramework: "mocha",   
+    env: {
+      type: 'node',
+      runner: 'node'
+    },
     compilers: {
       '**/*.js': wallaby.compilers.babel(),
     },
+    setup: function () {
+      require.extensions['.css'] = function () {return null;};
+      require.extensions['.png'] = function () {return null;};
+      require.extensions['.jpg'] = function () {return null;};
+      
+      var jsdom = require('jsdom').jsdom;
 
-    teardown: function(){
-      delete global.window;
-    },
-    
+      var exposedProperties = ['window', 'navigator', 'document'];
+
+      global.document = jsdom('');
+      global.window = document.defaultView;
+      Object.keys(document.defaultView).forEach((property) => {
+        if (typeof global[property] === 'undefined') {
+          exposedProperties.push(property);
+          global[property] = document.defaultView[property];
+        }
+      });
+
+      global.navigator = {
+        userAgent: 'node.js'
+      };
+    }
   };
 };


### PR DESCRIPTION
- Switch from sign browser environment (used by default) to node.
- Add the `setup` function that mostly copies `tools/testSetup.js` except for some bits that wallaby doesn't need.